### PR TITLE
fix: kupo still needed for current release

### DIFF
--- a/compose-partner-chains.yml
+++ b/compose-partner-chains.yml
@@ -18,6 +18,7 @@ volumes:
   db-sync-data: {}
   postgres-data: {}
   ogmios-data: {}
+  kupo-data: {}
 
 services:
   cardano-node:
@@ -85,3 +86,26 @@ services:
       - /config/preview/cardano-node/config.json
       - --host
       - 0.0.0.0
+
+  kupo:
+    image: cardanosolutions/kupo:v2.9.0
+    container_name: kupo
+    command:
+      - --node-socket
+      - /ipc/node.socket
+      - --node-config
+      - /config/config.json
+      - --host
+      - 0.0.0.0
+      - --workdir
+      - /db
+      - --match
+      - "*"
+      - --since
+      - "origin"
+    ports:
+      - "1442:1442"
+    volumes:
+      - kupo-data:/db
+      - ${HOME_IPC}:/ipc  # Use ${HOME_IPC} from .env
+      - $CARDANO_CONFIG_DIR:/config


### PR DESCRIPTION
Not dead yet... (only not needed from PC1.5 onwards)