### PR TITLE
Added cli wrappers to allow easy access to cli

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -11,7 +11,7 @@ export POSTGRES_USER="postgres"
 # A random password is used for your safety. Docker (but not podman) exposes
 # ports to the internet by default. This needs to be unguessable.
 if [ ! -f postgres.password ]; then
-    uuidgen | tr -d '-' | head -c 16 postgres.password
+    uuidgen | tr -d '-' | head -c 16 > postgres.password
 fi
 export POSTGRES_PASSWORD="$(cat ./postgres.password)"
 
@@ -42,6 +42,8 @@ export NODE_KEY="$(cat ./midnight-node.privatekey)"
 #
 # Partner chains config:
 #
+export CARDANO_NETWORK=preview
+export CARDANO_IMAGE="ghcr.io/intersectmbo/cardano-node:10.2.1"
 export CARDANO_DATA_DIR=./cardano-data
-export CARDANO_CONFIG_DIR=./cardano-config/preview
+export CARDANO_CONFIG_DIR=./cardano-config/${CARDANO_NETWORK}
 export HOME_IPC=${HOME}/ipc

--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,8 @@
 # If your on windows use wsl / git bash / cygwin / msys2 with direnv
 
-export MIDNIGHT_NODE_IMAGE="midnightnetwork/midnight-node:0.8.0"
+export MIDNIGHT_NODE_IMAGE="midnightnetwork/midnight-node:0.12.0"
+#TEMP OVERRIDE TILL RELEASED:
+export MIDNIGHT_NODE_IMAGE="ghcr.io/midnight-ntwrk/midnight-node:0.12.0-beta.3"
 
 export POSTGRES_HOST="x.x.x.x" # TODO: replace x.x.x.x with IP or host to postgres connection
 export POSTGRES_PORT="5432"

--- a/.envrc
+++ b/.envrc
@@ -4,7 +4,7 @@ export MIDNIGHT_NODE_IMAGE="midnightnetwork/midnight-node:0.12.0"
 #TEMP OVERRIDE TILL RELEASED:
 export MIDNIGHT_NODE_IMAGE="ghcr.io/midnight-ntwrk/midnight-node:0.12.0-beta.3"
 
-export POSTGRES_HOST="x.x.x.x" # TODO: replace x.x.x.x with IP or host to postgres connection
+export POSTGRES_HOST="postgres" # TODO: replace with IP or host to postgres connection if not connecting to the docker one.
 export POSTGRES_PORT="5432"
 export POSTGRES_USER="postgres"
 
@@ -12,8 +12,11 @@ export POSTGRES_USER="postgres"
 # ports to the internet by default. This needs to be unguessable.
 export POSTGRES_PASSWORD=$(< /dev/random tr -dc 'A-Za-z0-9!@#$%^&*()_+-=' | head -c 20)
 export POSTGRES_DB="cexplorer"
+
+# We bring together the above variables into a database connection string:
 export DB_SYNC_POSTGRES_CONNECTION_STRING="psql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB"
 
+# These are well known addresses of a network that allow you to discover all the other nodes.
 export BOOTNODES="/dns/boot-node-01.testnet-02.midnight.network/tcp/30333/ws/p2p/12D3KooWMjUq13USCvQR9Y6yFzYNYgTQBLNAcmc8psAuPx2UUdnB \
            /dns/boot-node-02.testnet-02.midnight.network/tcp/30333/ws/p2p/12D3KooWR1cHBUWPCqk3uqhwZqUFekfWj8T7ozK6S18DUT745v4d \
            /dns/boot-node-03.testnet-02.midnight.network/tcp/30333/ws/p2p/12D3KooWQxxUgq7ndPfAaCFNbAxtcKYxrAzTxDfRGNktF75SxdX5"
@@ -25,8 +28,12 @@ export APPEND_ARGS="--no-private-ip --validator --pool-limit 10 --trie-cache-siz
 export CFG_PRESET=testnet-02
 
 # Validator Values:
-# TODO: generate node key like this: docker run --rm -it docker.io/parity/subkey:latest generate-node-key. Use the second output for NODE_KEY
-export NODE_KEY=""
+if [ ! -f node.privatekey ]; then
+  # generate node key like this:
+  DOCKER_DEFAULT_PLATFORM=linux/amd64 docker run --rm -it docker.io/parity/subkey:latest generate-node-key  | sed -n '2p' > midnight-node.privatekey
+  # Use the second line of output for NODE_KEY (that's what sed -n '2p' does)
+fi
+export NODE_KEY="$(cat ./midnight-node.privatekey)"
 
 #
 # Partner chains config:

--- a/.envrc
+++ b/.envrc
@@ -11,7 +11,7 @@ export POSTGRES_USER="postgres"
 # A random password is used for your safety. Docker (but not podman) exposes
 # ports to the internet by default. This needs to be unguessable.
 if [ ! -f postgres.password ]; then
-    /dev/random tr -dc 'A-Za-z0-9!@#$%^&*()_+-=' | head -c 20 > postgres.password
+    uuidgen | tr -d '-' | head -c 16 postgres.password
 fi
 export POSTGRES_PASSWORD="$(cat ./postgres.password)"
 

--- a/.envrc
+++ b/.envrc
@@ -6,9 +6,7 @@
 git config --local commit.gpgSign true
 git config --local tag.gpgSign true
 
-export MIDNIGHT_NODE_IMAGE="midnightnetwork/midnight-node:0.12.0"
-#TEMP OVERRIDE TILL RELEASED:
-export MIDNIGHT_NODE_IMAGE="ghcr.io/midnight-ntwrk/midnight-node:0.12.0-beta.3"
+export MIDNIGHT_NODE_IMAGE="midnightnetwork/midnight-node:0.8.0"
 
 export POSTGRES_HOST="postgres" # TODO: replace with IP or host to postgres connection if not connecting to the docker one.
 export POSTGRES_PORT="5432"

--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,11 @@
 # If your on windows use wsl / git bash / cygwin / msys2 with direnv
 
+# This repo only accepts signed commits:
+# point out to users at commit time that commits need to be signed,
+# not once they've done many commits and are trying to push a PR:
+git config --local commit.gpgSign true
+git config --local tag.gpgSign true
+
 export MIDNIGHT_NODE_IMAGE="midnightnetwork/midnight-node:0.12.0"
 #TEMP OVERRIDE TILL RELEASED:
 export MIDNIGHT_NODE_IMAGE="ghcr.io/midnight-ntwrk/midnight-node:0.12.0-beta.3"

--- a/.envrc
+++ b/.envrc
@@ -10,7 +10,11 @@ export POSTGRES_USER="postgres"
 
 # A random password is used for your safety. Docker (but not podman) exposes
 # ports to the internet by default. This needs to be unguessable.
-export POSTGRES_PASSWORD=$(< /dev/random tr -dc 'A-Za-z0-9!@#$%^&*()_+-=' | head -c 20)
+if [ ! -f postgres.password ]; then
+    /dev/random tr -dc 'A-Za-z0-9!@#$%^&*()_+-=' | head -c 20 > postgres.password
+fi
+export POSTGRES_PASSWORD="$(cat ./postgres.password)"
+
 export POSTGRES_DB="cexplorer"
 
 # We bring together the above variables into a database connection string:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /cardano-data/*
 /data
+*.privatekey

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /cardano-data/*
+/data

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /cardano-data/*
 /data
 *.privatekey
+*.password

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
 
 ### 🚀 Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### 🚀 Features
+
+- Port from prior repo (#3)
+- If direnv isn't working give an appropriate error message.
+- /data dir should be .gitignored
+- Automatically create a random node key.
+- Only randomise the postgres password once.
+- Parametise cardano network
+
+### 💼 Other
+
+- *(deps)* Bump checkmarx/ast-github-action from 2.3.18 to 2.3.19 (#9)
+- Be explicit about image

--- a/README.md
+++ b/README.md
@@ -19,29 +19,36 @@ This allows for easy orchestration of the Midnight Node service.
 The `.envrc` file will automatically create a random private key and save it as `midnight-node.privatekey`.
 
 ```shell
-DOCKER_DEFAULT_PLATFORM=linux/amd64 docker-compose up -d
+docker compose up -d
 ```
 
 or for both Midnight and Cardano:
 
 ```shell
-DOCKER_DEFAULT_PLATFORM=linux/amd64 docker-compose -f ./compose-partner-chains.yml -f ./compose.yml up -d
+docker compose -f ./compose-partner-chains.yml -f ./compose.yml up -d
 ```
 
 or for Midnight, Cardano and a local Proof Server:
 
 ```shell
-DOCKER_DEFAULT_PLATFORM=linux/amd64 docker-compose -f ./compose-partner-chains.yml -f ./compose.yml -f ./proof-server.yml up -d
+docker compose -f ./compose-partner-chains.yml -f ./compose.yml -f ./proof-server.yml up -d
 ```
 
 🚀 That's it.
 
 ### Troubleshooting
 
+#### Env vars not setup
+
 If you get warnings like this then likely `direnv` is not setup or `direnv allow` has not been run:
 ```
 WARN[0000] The "HOME_IPC" variable is not set. Defaulting to a blank string.
 ```
+
+#### IPC Errors
+
+If you get IPC errors with Cardano node then delete the stale
+socket file: `rm ~/ipc/node.socket` and restart.
 
 ### LICENSE
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ docker compose -f ./compose-partner-chains.yml -f ./compose.yml -f ./proof-serve
 
 ### Troubleshooting
 
+### Clean start
+
+To restart from fresh, run:
+
+```sh
+docker compose -f ./compose-partner-chains.yml -f ./compose.yml -f ./proof-server.yml down -v
+docker compose -f ./compose-partner-chains.yml -f ./compose.yml -f ./proof-server.yml kill
+rm ~/ipc/node.socket
+rm -R ./data
+rm -R ./cardano-data
+```
+
 #### Env vars not setup
 
 If you get warnings like this then likely `direnv` is not setup or `direnv allow` has not been run:
@@ -49,6 +61,18 @@ WARN[0000] The "HOME_IPC" variable is not set. Defaulting to a blank string.
 
 If you get IPC errors with Cardano node then delete the stale
 socket file: `rm ~/ipc/node.socket` and restart.
+
+#### Midnight node Errors
+
+If you encounter this message on the midnight node it's likely that the
+cardano-node is still syncing and it will go away once it's fully synced:
+
+```
+Unable to author block in slot. Failure creating inherent data provider:
+'No latest block on chain.' not found.
+Possible causes: main chain follower configuration error, db-sync not synced fully,
+or data not set on the main chain.
+```
 
 ### LICENSE
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,18 @@ This allows for easy orchestration of the Midnight Node service.
 ## System requirements
 
 - Install [Docker-Compose](https://docs.docker.com/compose/install/)
+- Install [direnv](https://direnv.net/docs/installation.html)
+- Once cloned, run `direnv allow` once to set the environment variables.
 
 ## Usage
 
 1. Clone repo
 
-3. Modify values in `.envrc` file as applicable
+2. run `direnv allow` (only needs to be done when '.envrc` has been modified)
 
-2. Navigate to .yml file and `docker-compose up`
+3. Run `docker-compose up`
+
+The `.envrc` file will automatically create a random private key and save it as `midnight-node.privatekey`.
 
 ```shell
 DOCKER_DEFAULT_PLATFORM=linux/amd64 docker-compose up -d
@@ -31,6 +35,13 @@ DOCKER_DEFAULT_PLATFORM=linux/amd64 docker-compose -f ./compose-partner-chains.y
 ```
 
 🚀 That's it.
+
+### Troubleshooting
+
+If you get warnings like this then likely `direnv` is not setup or `direnv allow` has not been run:
+```
+WARN[0000] The "HOME_IPC" variable is not set. Defaulting to a blank string.
+```
 
 ### LICENSE
 

--- a/cardano-cli.sh
+++ b/cardano-cli.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+if [ "$CARDANO_NETWORK" = "preview" ]; then
+  CARDANO_NODE_NETWORK_ID=2
+elif [ "$CARDANO_NETWORK" = "mainnet" ]; then
+  CARDANO_NODE_NETWORK_ID=1
+elif [ "$CARDANO_NETWORK" = "preprod" ]; then
+  CARDANO_NODE_NETWORK_ID=0
+else
+  echo "Error: Unknown CARDANO_NETWORK: $CARDANO_NETWORK"
+  exit 1
+fi
+
+DOCKER_DEFAULT_PLATFORM=linux/amd64 docker run --rm \
+  --network container:cardano-node \
+  -e CARDANO_NODE_SOCKET_PATH="/ipc/node.socket" \
+  -e CARDANO_NODE_NETWORK_ID=${CARDANO_NODE_NETWORK_ID} \
+  -v ~/ipc:/ipc \
+  ${CARDANO_IMAGE} \
+  cli $*

--- a/compose-partner-chains.yml
+++ b/compose-partner-chains.yml
@@ -21,17 +21,17 @@ volumes:
 
 services:
   cardano-node:
-    image: ghcr.io/intersectmbo/cardano-node:10.2.1
+    image: ${CARDANO_IMAGE}
     restart: unless-stopped
     container_name: cardano-node
     ports:
       - "3001:3001"
     environment:
-      - NETWORK=preview
+      - NETWORK=${CARDANO_NETWORK}
       - CARDANO_NODE_SOCKET_PATH=/ipc/node.socket
     volumes:
       - ${HOME_IPC}:/ipc   # Use ${HOME_IPC} from .envrc
-      - $CARDANO_DATA_DIR:/data
+      - ${CARDANO_DATA_DIR}:/data
 
   postgres:
     image: postgres:15.3
@@ -59,8 +59,8 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      - NETWORK=preview
-      - POSTGRES_HOST=postgres
+      - NETWORK=${CARDANO_NETWORK}
+      - POSTGRES_HOST=${POSTGRES_HOST}
       - POSTGRES_PORT=${POSTGRES_PORT}
       - POSTGRES_DB=${POSTGRES_DB}
       - POSTGRES_USER=${POSTGRES_USER}
@@ -84,6 +84,6 @@ services:
       - --node-socket
       - /ipc/node.socket
       - --node-config
-      - /config/preview/cardano-node/config.json
+      - /config/${CARDANO_NETWORK}/cardano-node/config.json
       - --host
       - 0.0.0.0

--- a/compose-partner-chains.yml
+++ b/compose-partner-chains.yml
@@ -18,6 +18,7 @@ volumes:
   db-sync-data: {}
   postgres-data: {}
   ogmios-data: {}
+  kupo-data: {}
 
 services:
   cardano-node:
@@ -88,3 +89,26 @@ services:
       - /config/${CARDANO_NETWORK}/cardano-node/config.json
       - --host
       - 0.0.0.0
+
+  kupo:
+    image: cardanosolutions/kupo:v2.9.0
+    container_name: kupo
+    command:
+      - --node-socket
+      - /ipc/node.socket
+      - --node-config
+      - /config/config.json
+      - --host
+      - 0.0.0.0
+      - --workdir
+      - /db
+      - --match
+      - "*"
+      - --since
+      - "origin"
+    ports:
+      - "1442:1442"
+    volumes:
+      - kupo-data:/db
+      - ${HOME_IPC}:/ipc  # Use ${HOME_IPC} from .envrc
+      - $CARDANO_CONFIG_DIR:/config

--- a/compose-partner-chains.yml
+++ b/compose-partner-chains.yml
@@ -18,7 +18,6 @@ volumes:
   db-sync-data: {}
   postgres-data: {}
   ogmios-data: {}
-  kupo-data: {}
 
 services:
   cardano-node:
@@ -86,26 +85,3 @@ services:
       - /config/preview/cardano-node/config.json
       - --host
       - 0.0.0.0
-
-  kupo:
-    image: cardanosolutions/kupo:v2.9.0
-    container_name: kupo
-    command:
-      - --node-socket
-      - /ipc/node.socket
-      - --node-config
-      - /config/config.json
-      - --host
-      - 0.0.0.0
-      - --workdir
-      - /db
-      - --match
-      - "*"
-      - --since
-      - "origin"
-    ports:
-      - "1442:1442"
-    volumes:
-      - kupo-data:/db
-      - ${HOME_IPC}:/ipc  # Use ${HOME_IPC} from .envrc
-      - $CARDANO_CONFIG_DIR:/config

--- a/compose-partner-chains.yml
+++ b/compose-partner-chains.yml
@@ -21,7 +21,7 @@ volumes:
 
 services:
   cardano-node:
-    image: ghcr.io/intersectmbo/cardano-node:10.1.4
+    image: ghcr.io/intersectmbo/cardano-node:10.2.1
     restart: unless-stopped
     container_name: cardano-node
     ports:
@@ -35,6 +35,7 @@ services:
 
   postgres:
     image: postgres:15.3
+    platform: linux/amd64
     container_name: db-sync-postgres
     environment:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
@@ -51,6 +52,7 @@ services:
 
   db-sync:
     image: ghcr.io/intersectmbo/cardano-db-sync:13.6.0.4
+    platform: linux/amd64
     container_name: db-sync
     restart: unless-stopped
     depends_on:

--- a/compose.yml
+++ b/compose.yml
@@ -21,7 +21,6 @@ services:
     container_name: midnight
     restart: unless-stopped
     image: ${MIDNIGHT_NODE_IMAGE}
-    platform: linux/amd64
     ports:
       - "9944:9944"   # WebSocket   - For RPC/relay type of nodes (queries, new transaction submissions etc).
       - "30333:30333" # P2P Traffic - Peer-to-peer communication for node connectivity.

--- a/midnight-node.sh
+++ b/midnight-node.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+if [ -z "$MIDNIGHT_NODE_IMAGE" ]; then
+  echo "Error: Env var MIDNIGHT_NODE_IMAGE is not set or is empty"
+  echo "Please install direnv and run `direnv allow` to activate it."
+  exit 1
+fi
+
 docker run -it \
   -e CFG_PRESET=${CFG_PRESET} \
   -e DB_SYNC_POSTGRES_CONNECTION_STRING=${DB_SYNC_POSTGRES_CONNECTION_STRING} \

--- a/midnight-node.sh
+++ b/midnight-node.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+docker run -it \
+  -e CFG_PRESET=${CFG_PRESET} \
+  -e DB_SYNC_POSTGRES_CONNECTION_STRING=${DB_SYNC_POSTGRES_CONNECTION_STRING} \
+  -v ./data:/data ${MIDNIGHT_NODE_IMAGE} \
+  $*


### PR DESCRIPTION
This PR:

- Adds a small wrapper (`midnight-node.sh`) so that it's easier to execute cli commands if the binary is used from an image.
- Adds a small wrapper (`cardano-cli.sh`) so that it's easier to execute cli commands if the binary is used from an image.
- Ensures commits are signed via .envrc
- /dev/random isn't always readable on all machines. Alternative source of randomness used for password generation.
- Automatically creates a node key if one doesn't already exist.
