### PR TITLE
feat: use docker volume for IPC

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -53,4 +53,3 @@ export CARDANO_NETWORK=preview
 export CARDANO_IMAGE="ghcr.io/intersectmbo/cardano-node:10.2.1"
 export CARDANO_DATA_DIR=./cardano-data
 export CARDANO_CONFIG_DIR=./cardano-config/${CARDANO_NETWORK}
-export HOME_IPC=${HOME}/ipc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🚀 Features
 
-- Have Cardano's ipc socket stored in a docker volume so stale file can be recreated on all OSes.
+- Cardano's ipc socket file is now stored in a docker volume so when stale can be recreated on all OSes.
+- `cardano-cli.sh`, `midnight-node.sh` and `midnight-shell.sh` execute within the running container.
 - Switch networks by altering CFG_PRESET only
 - Added `test.sh` to detect problems and provide solutions.
 - Added `reset-midnight.sh` script to clear down midnight's blockchain.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🚀 Features
 
+- Have Cardano's ipc socket stored in a docker volume so stale file can be recreated on all OSes.
 - Switch networks by altering CFG_PRESET only
 - Added `test.sh` to detect problems and provide solutions.
 - Added `reset-midnight.sh` script to clear down midnight's blockchain.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ To restart from fresh, run:
 ```sh
 docker compose -f ./compose-partner-chains.yml -f ./compose.yml -f ./proof-server.yml down -v
 docker compose -f ./compose-partner-chains.yml -f ./compose.yml -f ./proof-server.yml kill
-rm ~/ipc/node.socket
 rm -R ./cardano-data
 docker volume rm midnight-node-docker_midnight-data-testnet
 ```

--- a/cardano-cli.sh
+++ b/cardano-cli.sh
@@ -13,5 +13,4 @@ fi
 
 # Run in same container as cardano-node.
 # docker exec doesn't support `--env` params so wrapped in an `sh`.
-args="$@"
-docker exec -t cardano-node sh -c "CARDANO_NODE_NETWORK_ID=${CARDANO_NODE_NETWORK_ID} /usr/local/bin/cardano-cli $args"
+docker exec -t cardano-node sh -c "CARDANO_NODE_NETWORK_ID=${CARDANO_NODE_NETWORK_ID} /usr/local/bin/cardano-cli $*"

--- a/cardano-cli.sh
+++ b/cardano-cli.sh
@@ -11,11 +11,7 @@ else
   exit 1
 fi
 
-DOCKER_DEFAULT_PLATFORM=linux/amd64 docker run --rm \
-  --network container:cardano-node \
-  -e CARDANO_NODE_SOCKET_PATH="/ipc/node.socket" \
-  -e CARDANO_NODE_NETWORK_ID="${CARDANO_NODE_NETWORK_ID}" \
-  -v ~/ipc:/ipc \
-  -v "${CARDANO_DATA_DIR}:/data" \
-  "${CARDANO_IMAGE}" \
-  cli "$@"
+# Run in same container as cardano-node.
+# docker exec doesn't support `--env` params so wrapped in an `sh`.
+args="$@"
+docker exec -t cardano-node sh -c "CARDANO_NODE_NETWORK_ID=${CARDANO_NODE_NETWORK_ID} /usr/local/bin/cardano-cli $args"

--- a/check-chain.sh
+++ b/check-chain.sh
@@ -106,9 +106,8 @@ else
 fi
 
 START_EPOCH=$CURRENT_EPOCH  # Assume EPOCH is already set
-for ((i = 0; i <= 10; i++)); do
+for ((i = 0; i <= 3; i++)); do
     CURRENT_EPOCH=$((START_EPOCH + i))
-    # echo "Checking epoch $CURRENT_EPOCH"
 
     # Replace this with your actual command and condition
     RESPONSE=$(curl -s -H "Content-Type: application/json" \

--- a/compose-partner-chains.yml
+++ b/compose-partner-chains.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 volumes:
-  cardano-data: {}
+  cardano-ipc: {}
   db-sync-data: {}
   postgres-data: {}
   ogmios-data: {}
@@ -31,7 +31,7 @@ services:
       - NETWORK=${CARDANO_NETWORK}
       - CARDANO_NODE_SOCKET_PATH=/ipc/node.socket
     volumes:
-      - ${HOME_IPC}:/ipc   # Use ${HOME_IPC} from .envrc
+      - cardano-ipc:/ipc
       - ${CARDANO_DATA_DIR}:/data
 
   postgres:
@@ -68,7 +68,7 @@ services:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     volumes:
-      - ${HOME_IPC}:/node-ipc  # Use ${HOME_IPC} from .envrc
+      - cardano-ipc:/node-ipc
       - db-sync-data:/var/lib
 
   cardano-ogmios:
@@ -81,7 +81,7 @@ services:
     ports:
       - "1337:1337"
     volumes:
-      - ${HOME_IPC}:/ipc  # Use ${HOME_IPC} from .envrc
+      - cardano-ipc:/ipc
       - ogmios-data:/data
     command:
       - --node-socket

--- a/midnight-node.sh
+++ b/midnight-node.sh
@@ -6,15 +6,4 @@ if [ -z "$MIDNIGHT_NODE_IMAGE" ]; then
   exit 1
 fi
 
-if [[ "$(uname)" == "Darwin" ]]; then
-  # For arm mac persuade docker to be more liberal:
-  export DOCKER_DEFAULT_PLATFORM=linux/arm64
-fi
-
-docker run -it \
-  -e CFG_PRESET="${CFG_PRESET}" \
-  -e DB_SYNC_POSTGRES_CONNECTION_STRING="${DB_SYNC_POSTGRES_CONNECTION_STRING}" \
-  -v ./data:/data \
-  -v "./envs/${CFG_PRESET}/pc-chain-config.json:/pc-chain-config.json" \
-  "${MIDNIGHT_NODE_IMAGE}" \
-  "$@"
+docker exec -t midnight /midnight-node "$@"


### PR DESCRIPTION
Cardano's ipc socket file is now stored in a docker volume so when stale can be recreated on all OSes. This means that this repo is now self contained and doesn't rely on writing to any file outside of the cloned dir. ( Potentially fixes https://github.com/midnightntwrk/midnight-node-docker/issues/17 )

`cardano-cli.sh` and `midnight-node.sh` now acts like `midnight-shell.sh` and executes within the running container.

----

Also a couple of tweaks to test scripts:

- registration only ever needs to look 3 epochs in the future.

- change test.sh to not rely on looking at ipc file to detect cardano status.