### PR TITLE
fix: checkmarx on main needs more permissions to upload results

### DIFF
--- a/.github/workflows/checkmarx.yaml
+++ b/.github/workflows/checkmarx.yaml
@@ -21,6 +21,7 @@ jobs:
       contents: read
       pull-requests: write
       statuses: write
+      security-events: write
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/checkmarx.yaml
+++ b/.github/workflows/checkmarx.yaml
@@ -5,6 +5,7 @@ permissions:
   contents: read             # we only need to checkout code
   actions: read              # to query workflows/runs
   pull-requests: write       # to comment on or label PRs
+  security-events: write     # to upload the scan results
 
 on:
   pull_request:


### PR DESCRIPTION
Checkmarx on main needs more permissions to upload results of the scan to github