### PR TITLE
feat(bau): check-chain script is bit more flexible

### DIFF
--- a/cardano-cli.sh
+++ b/cardano-cli.sh
@@ -1,5 +1,30 @@
 #!/usr/bin/env bash
 
+# Parse --cardano-network argument if present, otherwise use env var
+NETWORK_ARG=""
+NEW_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cardano-network)
+      NETWORK_ARG="$2"
+      shift 2
+      ;;
+    *)
+      NEW_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [ -n "$NETWORK_ARG" ]; then
+  CARDANO_NETWORK="$NETWORK_ARG"
+fi
+
+if [ -z "$CARDANO_NETWORK" ]; then
+  echo "Error: CARDANO_NETWORK not set. Please provide --cardano-network <network> or set the CARDANO_NETWORK environment variable."
+  exit 1
+fi
+
 if [ "$CARDANO_NETWORK" = "preview" ]; then
   CARDANO_NODE_NETWORK_ID=2
 elif [ "$CARDANO_NETWORK" = "mainnet" ]; then
@@ -13,4 +38,4 @@ fi
 
 # Run in same container as cardano-node.
 # docker exec doesn't support `--env` params so wrapped in an `sh`.
-docker exec -t cardano-node sh -c "CARDANO_NODE_NETWORK_ID=${CARDANO_NODE_NETWORK_ID} /usr/local/bin/cardano-cli $*"
+docker exec -t cardano-node sh -c "CARDANO_NODE_NETWORK_ID=${CARDANO_NODE_NETWORK_ID} /usr/local/bin/cardano-cli ${NEW_ARGS[*]}"

--- a/check-chain.sh
+++ b/check-chain.sh
@@ -2,8 +2,86 @@
 set -euo pipefail
 
 # ─── Configuration ─────────────────────────────────────────────────────────────
-RPC_URL="http://127.0.0.1:9944"     # your node’s JSON-RPC HTTP endpoint
-RPC_URL="https://rpc.qanet.dev.midnight.network/"
+# Accept parameters for RPC_URL and all env vars not set within this file.
+usage() {
+  echo "Usage: $0 [--rpc-url URL] [--postgres-password PASSWORD] [--postgres-port PORT] [--postgres-user USER] [--postgres-db DB] [--cardano-network NETWORK]"
+  echo ""
+  echo "All parameters are optional. If not provided, the script will use the corresponding environment variable."
+  echo "If neither is set, the script will exit with an error."
+  exit 1
+}
+
+# Default values from environment
+RPC_URL="${RPC_URL:-http://127.0.0.1:9933}"     # your node’s JSON-RPC HTTP endpoint
+# RPC_URL="https://rpc.qanet.dev.midnight.network/"
+
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-}"
+POSTGRES_PORT="${POSTGRES_PORT:-}"
+POSTGRES_USER="${POSTGRES_USER:-}"
+POSTGRES_DB="${POSTGRES_DB:-}"
+CARDANO_NETWORK="${CARDANO_NETWORK:-}"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --rpc-url)
+      RPC_URL="$2"
+      shift 2
+      ;;
+    --postgres-password)
+      POSTGRES_PASSWORD="$2"
+      shift 2
+      ;;
+    --postgres-port)
+      POSTGRES_PORT="$2"
+      shift 2
+      ;;
+    --postgres-user)
+      POSTGRES_USER="$2"
+      shift 2
+      ;;
+    --postgres-db)
+      POSTGRES_DB="$2"
+      shift 2
+      ;;
+    --cardano-network)
+      CARDANO_NETWORK="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      ;;
+    *)
+      echo "Unknown argument: $1"
+      usage
+      ;;
+  esac
+done
+
+# Validate required variables (report all missing at once)
+missing_vars=()
+[[ -z "$RPC_URL" ]] && missing_vars+=("RPC_URL")
+[[ -z "$POSTGRES_PASSWORD" ]] && missing_vars+=("POSTGRES_PASSWORD")
+[[ -z "$POSTGRES_PORT" ]] && missing_vars+=("POSTGRES_PORT")
+[[ -z "$POSTGRES_USER" ]] && missing_vars+=("POSTGRES_USER")
+[[ -z "$POSTGRES_DB" ]] && missing_vars+=("POSTGRES_DB")
+[[ -z "$CARDANO_NETWORK" ]] && missing_vars+=("CARDANO_NETWORK")
+
+if (( ${#missing_vars[@]} )); then
+  echo "❌ ERROR: The following required arguments are missing. You can provide them as command-line arguments:"
+  for var in "${missing_vars[@]}"; do
+    case "$var" in
+      RPC_URL) echo "  --rpc-url <value>" ;;
+      POSTGRES_PASSWORD) echo "  --postgres-password <value>" ;;
+      POSTGRES_PORT) echo "  --postgres-port <value>" ;;
+      POSTGRES_USER) echo "  --postgres-user <value>" ;;
+      POSTGRES_DB) echo "  --postgres-db <value>" ;;
+      CARDANO_NETWORK) echo "  --cardano-network <value>" ;;
+      *) echo "  $var" ;;
+    esac
+  done
+  exit 1
+fi
 
 echo Get genesis utxo from running midnight node...
 GET_PC_PARAMS="curl -s -H \"Content-Type:application/json\" \
@@ -12,11 +90,10 @@ GET_PC_PARAMS="curl -s -H \"Content-Type:application/json\" \
 GENESIS_UTXO=$(eval "$GET_PC_PARAMS" | jq -r '.result.genesis_utxo')
 echo "GENESIS_UTXO=$GENESIS_UTXO"
 
-
 export GENESIS_TX_HASH="${GENESIS_UTXO%%#*}"
 export GENESIS_COIN_INDEX="${GENESIS_UTXO##*#}"
-echo Check coin has been spent according to cardano...
-QUERY_UTXO_CMD="./cardano-cli.sh query utxo --tx-in $GENESIS_UTXO --output-json 2>/dev/null"
+echo Check if coin has been spent according to cardano...
+QUERY_UTXO_CMD="./cardano-cli.sh query utxo --tx-in $GENESIS_UTXO --output-json --cardano-network $CARDANO_NETWORK"
 genesis_utxo_json=$(eval "$QUERY_UTXO_CMD");
 
 if [ "$genesis_utxo_json" = "{}" ] ; then
@@ -25,7 +102,15 @@ else
     echo "❌ As part of chain registration process Genesis UTXO should have been spent but $genesis_utxo_json"
 fi
 
-# Assume that db-sync is synced.
+# DB-sync should be synced!
+tip_json=$(docker exec cardano-node cardano-cli query tip --socket-path /ipc/node.socket --testnet-magic 2)
+sync_progress=$(echo "$tip_json" | jq -r '.syncProgress')
+if [[ "$sync_progress" != "100.00" ]]; then
+    echo "❌ ERROR: DB-sync is not fully synced. syncProgress=$sync_progress"
+    exit 1
+else
+    echo "✅ Cardano-node is at the latest tip, synced."
+fi
 
 # Find spent UTXO:
 export PGPASSWORD=$POSTGRES_PASSWORD
@@ -55,12 +140,11 @@ else
     # can show url to tx hash https://preview.cexplorer.io/tx/1bb8027cb698c4b4c829396ac6eabac2ad46d80744c7a6822298dd76633c4f4f
 fi
 
-
-EPOCH_CMD="./cardano-cli.sh query tip 2>/dev/null"
+echo "Querying Cardano chain tip for current epoch..."
+EPOCH_CMD="./cardano-cli.sh query tip --cardano-network $CARDANO_NETWORK 2>/dev/null"
 tip=$(eval "$EPOCH_CMD");
 CURRENT_EPOCH=$(echo "$tip" | jq -r '.epoch')
-echo "epoc=$CURRENT_EPOCH"
-
+echo "Current Cardano epoch: $CURRENT_EPOCH"
 
 # curl -s -H "Content-Type:application/json" -d '{"jsonrpc":"2.0","method":"sidechain_getStatus","params":[],"id":1}' https://rpc.qanet.dev.midnight.network/
 
@@ -142,8 +226,6 @@ done
 
 # midnight_apiVersions
 # midnight_ledgerVersion
-
-
 
 # Registrations status for epoch 929:
 # running external command: /midnight-node registration-status --mainchain-pub-key 0x1f4bf447da2b78482b2656f7f504b321c9f0b8712faabbd0de7c47ab13d9cd4a --mc-epoch-number 929 --chain chain-spec.json --base-path /tmp/.tmpii6vGf


### PR DESCRIPTION
## Summary
- Make `check-chain.sh` and `cardano-cli.sh` accept all configuration via CLI arguments (--rpc-url, --postgres-password, --postgres-port, --postgres-user, --postgres-db, --cardano-network)
- Fall back to environment variables when CLI arguments are not provided, with clear error messages listing all missing parameters
- Add cardano-node sync progress check before running db-sync queries
- Default RPC URL changed to `http://127.0.0.1:9933`