### PR TITLE
Revert attempt to be friendlier to forks

### DIFF
--- a/.github/workflows/checkmarx.yaml
+++ b/.github/workflows/checkmarx.yaml
@@ -8,8 +8,8 @@ permissions:
   security-events: write     # to upload the scan results
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+  pull_request:
+    branches: [ '**' ]
   push:
     branches: [ 'main' ]
 concurrency:
@@ -26,30 +26,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # From https://michaelheap.com/access-secrets-from-forks/
-      # Also see https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
-      - name: Get User Permission
-        id: checkAccess
-        uses: actions-cool/check-user-permission@7b90a27f92f3961b368376107661682c441f6103  #v2
-        with:
-          require: write
-          username: ${{ github.triggering_actor }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Check User Permission
-        if: steps.checkAccess.outputs.require-result == 'false'
-        run: |
-          echo "${{ github.triggering_actor }} does not have permissions on this repo."
-          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
-          echo "Job originally triggered by ${{ github.actor }}"
-          exit 1
-
-      # This is dangerous without the first access check
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  #v5.0.0
-        with:
-          # Yes we do need to specify head explicitly here (read github article)
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/checkmarx.yaml
+++ b/.github/workflows/checkmarx.yaml
@@ -8,14 +8,6 @@ permissions:
   security-events: write     # to upload the scan results
 
 on:
-  # pull_request_target allows secrets to be read from fork PRs.
-  # DO NOT build or run checked out code from this job.
-  #
-  # Please note: Due to how this job is run, any changes to this
-  # job will only take affect when merged to main.
-  #
-  # From https://michaelheap.com/access-secrets-from-forks/
-  # Also see https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
   pull_request_target:
     types: [opened, synchronize, reopened]
   push:
@@ -34,10 +26,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check access
-        if: ${{ github.event.pull_request.author_association != 'COLLABORATOR' && github.event.pull_request.author_association != 'OWNER' }}
+      # From https://michaelheap.com/access-secrets-from-forks/
+      # Also see https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+      - name: Get User Permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@7b90a27f92f3961b368376107661682c441f6103  #v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check User Permission
+        if: steps.checkAccess.outputs.require-result == 'false'
         run: |
-          echo "This job needs re-running by someone with collaboration permissions."
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
           exit 1
 
       # This is dangerous without the first access check

--- a/.github/workflows/checkmarx.yaml
+++ b/.github/workflows/checkmarx.yaml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Check access
-        if: ${{ github.event.pull_request.author_association != 'COLLABORATOR' && github.event.pull_request.author_association != 'OWNER' && github.event.pull_request.author_association != 'MEMBER' }}
+        if: ${{ github.event.pull_request.author_association != 'COLLABORATOR' && github.event.pull_request.author_association != 'OWNER' }}
         run: |
           echo "This job needs re-running by someone with collaboration permissions."
           exit 1
@@ -108,11 +108,6 @@ jobs:
         run: |
           mv ./cx_result.sarif ./cx_result.sarif.orig
           jq '.runs |= map(.results |= map(.locations |= map(if .physicalLocation.artifactLocation.uri == "" then .physicalLocation.artifactLocation.uri = "file:/README.md" else . end)))' cx_result.sarif.orig > cx_result.sarif
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: cx_result-sarif
-          path: cx_result.sarif
 
       # Upload results to github
       - name: Upload SARIF file


### PR DESCRIPTION
sscs-scorecard complains heavily about this. We'll have to do things manually till we come up with a better solution.

"ruleId": "Dangerous-Workflow - DangerousWorkflowID (sscs-scorecard)",
          "level": "error",
          "message": {
            "text": "score is 0: untrusted code checkout &#39;${{ github.event.pull_request.head.sha }}&#39;"
          },