### PR TITLE
chore: Update Checkmarx workflow to use main branch action

### DIFF
--- a/.github/workflows/checkmarx.yaml
+++ b/.github/workflows/checkmarx.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           repository: midnightntwrk/upload-sarif-github-action
-          ref: sean/PM-19431-fork-friendly-checkmarx  # Use branch until merged
+          ref: main
           path: upload-sarif-github-action
           token: ${{ secrets.MIDNIGHTCI_REPO }}
 


### PR DESCRIPTION
Updates the Checkmarx workflow to use the main branch of `upload-sarif-github-action` now that the fork-friendly implementation has been merged.

## What changed
- Updated workflow ref from `sean/PM-19431-fork-friendly-checkmarx` to `main`

## Why
The fork-friendly Checkmarx action with SCS/Scorecard support has been merged to main in https://github.com/midnightntwrk/upload-sarif-github-action/pull/25

## Testing
Successfully tested in PR #58 with a real fork PR

## Related
- PM-19431: Enable Checkmarx scanning for fork PRs
- Depends on: https://github.com/midnightntwrk/upload-sarif-github-action/pull/25 (merged)