### PR TITLE
ci: update scanner

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -27,4 +27,4 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  #v6.0.2
 
       - name: Scan code
-        uses: midnightntwrk/upload-sarif-github-action/scan@9856edc26a43e2d0cc3b391888bce2295377bdd7
+        uses: midnightntwrk/upload-sarif-github-action@9856edc26a43e2d0cc3b391888bce2295377bdd7

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -27,4 +27,4 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  #v6.0.2
 
       - name: Scan code
-        uses: midnightntwrk/upload-sarif-github-action/scan@4a845f28b9c18477052e3ee02c4e549970b1e904
+        uses: midnightntwrk/upload-sarif-github-action/scan@9856edc26a43e2d0cc3b391888bce2295377bdd7


### PR DESCRIPTION
Use latest versions of security scanners. scan is now not a sub-action.