### PR TITLE
Add dependabot cooldown of 7 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
- Adds `cooldown: default-days: 7` to all package ecosystem entries in dependabot.yml (including commented-out ones)
- Matches the pattern already established in midnight-template-repo