### PR TITLE
docs: mark testnet-02 as retired and document current networks

### DIFF
--- a/.envrc.testnet-02
+++ b/.envrc.testnet-02
@@ -1,3 +1,6 @@
+# RETIRED: testnet-02 was shut down in January 2026 and its bootnodes no
+# longer resolve. This preset is kept for reference only; see README for the
+# current network situation.
 # overrides for testnet-02
 export MIDNIGHT_NODE_IMAGE="midnightnetwork/midnight-node:0.12.0"
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This allows for easy orchestration of the Midnight Node service.
 
 1. Clone repository
 
-2. In `.envrc` set CFG_PRESET to be the environment you wish to point to (E.g. testnet-02).
+2. In `.envrc` set `CFG_PRESET` to the preset you wish to point to (the default is `testnet-02`, which is retired — see [Networks](#networks)).
 
 3. run `direnv allow` to load the environment variables
 
@@ -47,6 +47,12 @@ docker compose -f ./compose-partner-chains.yml -f ./compose.yml -f ./proof-serve
 ```
 
 🚀 That's it.
+
+### Networks
+
+`testnet-02` was retired in January 2026 and its endpoints no longer resolve. The current public networks are `preview`, `preprod` and `mainnet`; see the [networks and environments](https://docs.midnight.network/docs/guides/networks-and-environments) documentation for endpoints and migration guidance.
+
+The presets shipped in this repository are `qanet` (internal network) and the retired `testnet-02` (kept for reference). Updated presets for the current public networks are tracked in [midnight-docs issue #1172](https://github.com/midnightntwrk/midnight-docs/issues/1172).
 
 ### Troubleshooting
 


### PR DESCRIPTION
# Overview

`testnet-02` was retired in January 2026 and its endpoints no longer resolve (verified NXDOMAIN), but the README still told new users to set `CFG_PRESET=testnet-02` as the example preset — sending every new integrator to a dead network first.

Changes:
- README: the `CFG_PRESET` example no longer points at the retired network; added a short **Networks** section documenting the current public networks (`preview`, `preprod`, `mainnet`), the docs page for endpoints/migration, and the status of the presets shipped in this repo.
- `.envrc.testnet-02`: marked as RETIRED (kept for reference; no behavior change).

No config or behavior changes — documentation only. The default `CFG_PRESET` in `.envrc` is intentionally left untouched: the only other in-repo preset (`qanet`) targets an internal network, and updated presets for the public networks need the newer chain-config schema and node image, which is a maintainer decision (tracked in midnightntwrk/midnight-docs#1172).

## Submission Checklist

- [x] Useful pull request description
- [ ] Tests are provided (if possible) — docs-only change, existing CI covers config validation
- [x] Key commits have useful messages
- [ ] All check jobs of the CI have succeeded — awaiting CI run
- [x] Self-reviewed the diff
- [x] Reviewer requested
- [x] Update README.md file (if relevant)
- [ ] Update documentation (if relevant)
- [x] No new todos introduced

## Links

- Contributes to https://github.com/midnightntwrk/midnight-docs/issues/1172 (stale testnet-02 references across org repos, names this repo's README and .envrc)
- References #76 (testnet-02 preset cannot run with newer node images)